### PR TITLE
change default group to 'All' and remove 'Route' group

### DIFF
--- a/groupinfo.txt
+++ b/groupinfo.txt
@@ -1,4 +1,3 @@
-default-select-group = Route[仅海外代理 Exclude CN]
-select-group = All[全局代理 All Proxy]
+default-select-group = All[全局代理 All Proxy]
 auto-select-group = false
 config-per-group = /etc/ocserv/config-per-group


### PR DESCRIPTION
AnyConnect can`t correctly handle chinese characters in group description, this little fix configure ocserver to have only 1 group, so AnyConnect will do not need to show you 'Choose group' menu