### PR TITLE
添加frpc客户端

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM alpine:3.7
-
-MAINTAINER Tommy Lau <tommy@gen-new.com>
-
 ENV OC_VERSION=0.12.1
 
 RUN buildDeps=" \
@@ -21,12 +18,13 @@ RUN buildDeps=" \
 		xz \
 	"; \
 	set -x \
+	&& sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
 	&& apk add --update --virtual .build-deps $buildDeps \
 	&& curl -SL "ftp://ftp.infradead.org/pub/ocserv/ocserv-$OC_VERSION.tar.xz" -o ocserv.tar.xz \
 	&& curl -SL "ftp://ftp.infradead.org/pub/ocserv/ocserv-$OC_VERSION.tar.xz.sig" -o ocserv.tar.xz.sig \
-	&& gpg --keyserver pgp.mit.edu --recv-key 7F343FA7 \
-	&& gpg --keyserver pgp.mit.edu --recv-key 96865171 \
-	&& gpg --verify ocserv.tar.xz.sig \
+#	&& gpg --keyserver pgp.mit.edu --recv-key 7F343FA7 \
+#	&& gpg --keyserver pgp.mit.edu --recv-key 96865171 \
+#	&& gpg --verify ocserv.tar.xz.sig \
 	&& mkdir -p /usr/src/ocserv \
 	&& tar -xf ocserv.tar.xz -C /usr/src/ocserv --strip-components=1 \
 	&& rm ocserv.tar.xz* \
@@ -67,10 +65,15 @@ RUN set -x \
 
 WORKDIR /etc/ocserv
 
+# Frp frp_0.16.0_linux_386.tar.gz
+COPY frpc /usr/bin/frpc
+COPY frpc_full.ini /etc/frp/frpc_full.ini
 COPY All /etc/ocserv/config-per-group/All
 COPY cn-no-route.txt /etc/ocserv/config-per-group/Route
-
 COPY docker-entrypoint.sh /entrypoint.sh
+
+RUN chmod a+x /usr/bin/frpc
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 443

--- a/README.md
+++ b/README.md
@@ -1,23 +1,12 @@
 # docker-ocserv
 
-docker-ocserv is an OpenConnect VPN Server boxed in a Docker image built by [Tommy Lau](mailto:tommy@gen-new.com).
+docker-ocserv is an OpenConnect VPN Server boxed in a Docker image base on [Tommy Lau](mailto:tommy@gen-new.com).
 
-## Update on Aug 31, 2017
+## Update on 2018/11/02
 
-Update to version 0.11.8 and use Alpine 3.6 as base image
+Update to version 0.12.1 and use Alpine 3.7 as base image
 
-## Update on July 20,2016
-
-You can login with two group (`Route`/`ALL`) from now on.
-`Route` group means you can access China Mainland website directly and other connection will be protected by OpenConnect VPN
-`All` group means all of connection will be protected by OpenConnect VPN 
-
-## Update on July 16, 2016
-
-Thanks for [@sempr](https://github.com/sempr)'s contribution and suggestion, from now on, the [Alpine Linux](https://hub.docker.com/_/alpine/) will be used as the base image. The docker image size has been dramatically reduced from around 150MB to only 20MB.
-
-> NOTICE: You have to use Docker version 1.9.0 or later to support Alpine, DO NOT UPDATE the image if your Docker version is older than 1.9.0
-
+Add Frpc-0.16.0 and config to base image
 
 
 ## What is OpenConnect Server?
@@ -29,16 +18,16 @@ Thanks for [@sempr](https://github.com/sempr)'s contribution and suggestion, fro
 Get the docker image by running the following commands:
 
 ```bash
-docker pull tommylau/ocserv
+docker pull registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
 Start an ocserv instance:
 
 ```bash
-docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -d tommylau/ocserv
+docker run --name ocserv --privileged -p 1443:443 -p 1443:443/udp -e "server_addr=<ip/domain>" -e "privilege_token=<token_on_frps>" -e "hostname_in_docker=<name_on_frpc>" -d  registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
-This will start an instance with the a test user named `test` and password is also `test`.
+This will start an instance with the a test user named `heaven` and password is also `null`.
 
 ### Environment Variables
 
@@ -74,31 +63,31 @@ The default values of the above environment variables:
 Start an instance out of the box with username `test` and password `test`
 
 ```bash
-docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -d tommylau/ocserv
+docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -d registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
 Start an instance with server name `my.test.com`, `My Test` and `365` days
 
 ```bash
-docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e SRV_CN=my.test.com -e SRV_ORG="My Test" -e SRV_DAYS=365 -d tommylau/ocserv
+docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e SRV_CN=my.test.com -e SRV_ORG="My Test" -e SRV_DAYS=365 -d registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
 Start an instance with CA name `My CA`, `My Corp` and `3650` days
 
 ```bash
-docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e CA_CN="My CA" -e CA_ORG="My Corp" -e CA_DAYS=3650 -d tommylau/ocserv
+docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e CA_CN="My CA" -e CA_ORG="My Corp" -e CA_DAYS=3650 -d registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
 A totally customized instance with both CA and server certification
 
 ```bash
-docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e CA_CN="My CA" -e CA_ORG="My Corp" -e CA_DAYS=3650 -e SRV_CN=my.test.com -e SRV_ORG="My Test" -e SRV_DAYS=365 -d tommylau/ocserv
+docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e CA_CN="My CA" -e CA_ORG="My Corp" -e CA_DAYS=3650 -e SRV_CN=my.test.com -e SRV_ORG="My Test" -e SRV_DAYS=365 -d registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
 Start an instance as above but without test user
 
 ```bash
-docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e CA_CN="My CA" -e CA_ORG="My Corp" -e CA_DAYS=3650 -e SRV_CN=my.test.com -e SRV_ORG="My Test" -e SRV_DAYS=365 -e NO_TEST_USER=1 -v /some/path/to/ocpasswd:/etc/ocserv/ocpasswd -d tommylau/ocserv
+docker run --name ocserv --privileged -p 443:443 -p 443:443/udp -e CA_CN="My CA" -e CA_ORG="My Corp" -e CA_DAYS=3650 -e SRV_CN=my.test.com -e SRV_ORG="My Test" -e SRV_DAYS=365 -e NO_TEST_USER=1 -v /some/path/to/ocpasswd:/etc/ocserv/ocpasswd -d registry.cn-hangzhou.aliyuncs.com/sourcegarden/ocserv-fp:v1.7
 ```
 
 **WARNING:** The ocserv requires the ocpasswd file to start, if `NO_TEST_USER=1` is provided, there will be no ocpasswd created, which will stop the container immediately after start it. You must specific a ocpasswd file pointed to `/etc/ocserv/ocpasswd` by using the volume argument `-v` by docker as demonstrated above.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,10 +54,37 @@ if [ ! -f /etc/ocserv/certs/server-key.pem ] || [ ! -f /etc/ocserv/certs/server-
 
 	# Create a test user
 	if [ -z "$NO_TEST_USER" ] && [ ! -f /etc/ocserv/ocpasswd ]; then
-		echo "Create test user 'test' with password 'test'"
-		echo 'test:Route,All:$5$DktJBFKobxCFd7wN$sn.bVw8ytyAaNamO.CvgBvkzDiFR6DaHdUzcif52KK7' > /etc/ocserv/ocpasswd
+		echo "Create test user 'heaven' with password 'echoinheaven'"
+		echo 'heaven:Route,All:$1$fdjc.IJg$mTCHgZHlnvrf54s0At6MX.' > /etc/ocserv/ocpasswd
 	fi
 fi
+
+if [ -z "$server_addr" ]; then
+	server_addr=0.0.0.0
+fi
+if [ -z "$server_port" ]; then
+	server_port=7000
+fi
+if [ -z "$privilege_token" ]; then
+	privilege_token=12345678
+fi
+if [ -z "$login_fail_exit" ]; then
+	login_fail_exit=true
+fi
+
+if [ -z "$hostname_in_docker" ]; then
+        hostname_in_docker=hostname_in_docker
+fi
+
+sed -i 's/server_addr = 0.0.0.0/server_addr = '$server_addr'/' /etc/frp/frpc_full.ini
+sed -i 's/server_port = 7000/server_port = '$server_port'/' /etc/frp/frpc_full.ini
+sed -i 's/privilege_token = 12345678/privilege_token = '$privilege_token'/' /etc/frp/frpc_full.ini
+sed -i 's/login_fail_exit = true/login_fail_exit = '$login_fail_exit'/' /etc/frp/frpc_full.ini
+sed -i 's/hostname_in_docker/'$hostname_in_docker'/' /etc/frp/frpc_full.ini
+
+/usr/bin/frpc -c /etc/frp/frpc_full.ini &
+
+
 
 # Open ipv4 ip forward
 sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
添加frpc0.16.0,使ocserv支持更多的场景,例如:企业内部,通过frpc 实现内网穿透,使没有公网IP的主机也可以作为Ocserv服务器

修改readme.md

去掉了gpg校验(在中国可能由于网络问题,导致gpg无法校验)

去掉了dockerfile 中的 "作者"(开始没想合并到master,只是自己用,所以就给去掉了)
